### PR TITLE
fix: nocobase#4979

### DIFF
--- a/docs/en-US/welcome/getting-started/installation/git-clone.md
+++ b/docs/en-US/welcome/getting-started/installation/git-clone.md
@@ -5,7 +5,7 @@
 Make sure you have:
 
 - Git, Node.js 18+, Yarn 1.22.x installed
-- Configured and started the required database MySQL 8.x, MariaDB 10.9+, PostgreSQL 10+ choose one
+- Configured and started the required database &mdash; MySQL 8.x, MariaDB 10.9+, PostgreSQL 10+ &mdash; choose any one.
 
 ## 1. Download with Git
 
@@ -28,7 +28,7 @@ git clone https://github.com/nocobase/nocobase.git -b next --depth=1 my-nocobase
 ## 2. Switch to the project directory
 
 ```bash
-cd my-nocobase-app
+cd my-nocobase
 ```
 
 ## 3. Install dependencies

--- a/docs/zh-CN/welcome/getting-started/installation/git-clone.md
+++ b/docs/zh-CN/welcome/getting-started/installation/git-clone.md
@@ -28,7 +28,7 @@ git clone https://github.com/nocobase/nocobase.git -b next --depth=1 my-nocobase
 ## 2. 切换目录
 
 ```bash
-cd my-nocobase-app
+cd my-nocobase
 ```
 
 ## 3. 安装依赖


### PR DESCRIPTION
fix: welcome/getting-started/installation/git-clone (en-US, zh-CN)

Addressed issue#4979 in the _nocobase_ repo @ https://github.com/nocobase/nocobase/issues/4979#issue-2443915157

- Correct `cd my-nocobase-app` to `cd my-nocobase` in _git-clone.md_ (for both, en-US and zh-CN)
- Improve the readability and comprehensibility of text in bullet point 2 of '0. Prerequisites' in _git-clone.md_ (en-US)