### PR TITLE
docs: split sql client installation to seperate  doc

### DIFF
--- a/docs/en-US/handbook/backups/index.md
+++ b/docs/en-US/handbook/backups/index.md
@@ -12,66 +12,11 @@ This plugin is built into the NocoBase Professional Edition and does not require
 
 :::warning{title="Attention"}
 - This plugin is based on the native database client. Before using it, the corresponding database client must be installed in the NocoBase server environment.
+  - [PostgreSQL client installation](./installation/postgres.md)
+  - [MySQL client installation](./installation/mysql.md)
+  - [MariaDB client installation](./installation/mariadb.md)
 - During the restore operation, the version of the target database should not be lower than the version of the database that created the backup.
 :::
-
-### MySQL/MariaDB Client Installation
-
-Please select the database version that will be used when restoring backups to ensure compatibility.
-
-#### Docker Environment
-
-1. Visit the official MySQL release page, choose the appropriate MySQL version, and copy the download link.
-- Historical versions: https://downloads.mysql.com/archives/community/
-- Latest version: https://dev.mysql.com/downloads/mysql/
-
-The NocoBase image is built on the Debian 11 system, so select the corresponding MySQL client version for Debian 11. For example, to download version 8.1.0, find the download link from the above pages: https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_8.1.0-1debian11_amd64.deb
-
-2. Enter the NocoBase container
-```bash
-docker exec -it nocobase bash
-```
-
-3. Install the MySQL client:
-```bash
-apt-get update && apt-get install -y wget
-wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_8.1.0-1debian11_amd64.deb
-dpkg -x mysql-community-client-core_8.1.0-1debian11_amd64.deb /tmp/mysql-client
-cp /tmp/mysql-client/usr/bin/mysqldump /usr/bin/
-cp /tmp/mysql-client/usr/bin/mysql /usr/bin/
-```
-
-#### Other server environments
-
-Please visit the official MySQL release page, choose the appropriate MySQL version, and follow the official MySQL documentation for installation.
-- Historical versions: https://downloads.mysql.com/archives/community/
-- Latest version: https://dev.mysql.com/downloads/mysql/
-
-### PostgreSQL Client Installation
-
-Please select the database version that will be used when restoring backups to ensure version compatibility.
-
-#### Docker Environment
-
-1. Enter the NocoBase container
-```bash
-# for docker
-# docker exec -it nocobase bash
-
-# for docker compose
-docker compose exec -it app bash
-```
-
-2. Install the PostgreSQL client:
-```
-apt install -y postgresql-common gnupg
-/usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-# postgresql-client-16 is for version 16; choose the appropriate version as needed
-apt install -y postgresql-client-16
-```
-
-#### Other server environments
-Please visit https://www.postgresql.org/download/, choose the appropriate PostgreSQL version, and follow the official documentation for installation.
 
 ## Instructions
 

--- a/docs/en-US/handbook/backups/installation/mariadb.md
+++ b/docs/en-US/handbook/backups/installation/mariadb.md
@@ -1,0 +1,94 @@
+# MariaDB Client Installation
+
+## Docker Installation
+
+### Enter the directory where the NocoBase Dockerfile is located and create a Dockerfile file
+
+```Dockerfile
+# Based on the next version
+FROM registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
+
+# run installation script, choose the latest version of mysql
+RUN apt-get update && apt-get install -y wget && \
+ wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_8.1.0-1debian11_amd64.deb && \
+ dpkg -x mysql-community-client-core_8.1.0-1debian11_amd64.deb /tmp/mysql-client && \
+ cp /tmp/mysql-client/usr/bin/mysqldump /usr/bin/ &&\
+ cp /tmp/mysql-client/usr/bin/mysql /usr/bin/
+ ```
+
+### Modify the docker-compose.yml file of NocoBase
+
+```diff
+version: "3"
+
+networks:
+  nocobase:
+    driver: bridge
+
+services:
+  app:
+-   image: nocobase/nocobase:latest
++   build:
++     dockerfile: Dockerfile
+    networks:
+      - nocobase
+    depends_on:
+      - mariadb
+    environment:
+      # The application's secret key, used to generate user tokens, etc.
+      # If APP_KEY is changed, old tokens will also become invalid.
+      # It can be any random string, and make sure it is not exposed.
+      - APP_KEY=your-secret-key
+      # Database type, supports postgres, mysql, mariadb
+      - DB_DIALECT=mariadb
+      # Database host, can be replaced with the IP of an existing database server
+      - DB_HOST=mariadb
+      # Database name
+      - DB_DATABASE=nocobase
+      # Database user
+      - DB_USER=root
+      # Database password
+      - DB_PASSWORD=nocobase
+      # Whether to convert table and field names to snake case
+      - DB_UNDERSCORED=true
+      # Timezone
+      - TZ=Asia/Shanghai
+    volumes:
+      - ./storage:/app/nocobase/storage
+    ports:
+      - "13000:80"
+    # init: true
+
+  # If using an existing database server, mariadb service can be omitted
+  mariadb:
+    image: mariadb:11
+    environment:
+      MYSQL_DATABASE: nocobase
+      MYSQL_USER: nocobase
+      MYSQL_PASSWORD: nocobase
+      MYSQL_ROOT_PASSWORD: nocobase
+    restart: always
+    volumes:
+      - ./storage/db/mariadb:/var/lib/mysql
+    networks:
+      - nocobase
+```
+
+### Upgrade
+
+Previously, you would pull a new image for each update. Now, you need to build a new image for each update.
+
+```diff
+# Pull the latest image
+- docker-compose pull app
+# Rebuild the app container
++ docker-compose build app --pull
+# Start the app
+docker-compose up -d app
+# Check app logs
+docker-compose logs app
+```
+
+## Other Installation Methods
+If your NocoBase was installed with [create-nocobase-app](/welcome/getting-started/installation/create-nocobase-app) or [Git source code](/welcome/getting-started/installation/git-clone), please check the below MySQL official release page, and follow the official installation guide.
+- Last versions: https://dev.mysql.com/downloads/mysql/

--- a/docs/en-US/handbook/backups/installation/mysql.md
+++ b/docs/en-US/handbook/backups/installation/mysql.md
@@ -1,0 +1,95 @@
+# MySQL Client Installation
+
+## Docker Installation
+
+### Enter the directory where the NocoBase Dockerfile is located and create a Dockerfile file
+
+```Dockerfile
+# Based on the next version
+FROM registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
+
+# run installation script, please replace the corresponding MySQL version link according to the actual situation
+RUN apt-get update && apt-get install -y wget && \
+ wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_8.1.0-1debian11_amd64.deb && \
+ dpkg -x mysql-community-client-core_8.1.0-1debian11_amd64.deb /tmp/mysql-client && \
+ cp /tmp/mysql-client/usr/bin/mysqldump /usr/bin/ &&\
+ cp /tmp/mysql-client/usr/bin/mysql /usr/bin/
+ ```
+
+### Modify the docker-compose.yml file of NocoBase
+
+```diff
+version: "3"
+
+networks:
+  nocobase:
+    driver: bridge
+
+services:
+  app:
+-   image: nocobase/nocobase:latest
++   build:
++     dockerfile: Dockerfile
+    networks:
+      - nocobase
+    depends_on:
+      - mysql
+    environment:
+      # The application's secret key, used to generate user tokens, etc.
+      # If APP_KEY is changed, old tokens will also become invalid.
+      # It can be any random string, and make sure it is not exposed.
+      - APP_KEY=your-secret-key
+      # Database type, supports postgres, mysql, mariadb
+      - DB_DIALECT=mysql
+      # Database host, can be replaced with the IP of an existing database server
+      - DB_HOST=mysql
+      # Database name
+      - DB_DATABASE=nocobase
+      # Database user
+      - DB_USER=root
+      # Database password
+      - DB_PASSWORD=nocobase
+      # Whether to convert table and field names to snake case
+      - DB_UNDERSCORED=true
+      # Timezone
+      - TZ=Asia/Shanghai
+    volumes:
+      - ./storage:/app/nocobase/storage
+    ports:
+      - "13000:80"
+    # init: true
+
+  # If using an existing database server, mysql service can be omitted
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_DATABASE: nocobase
+      MYSQL_USER: nocobase
+      MYSQL_PASSWORD: nocobase
+      MYSQL_ROOT_PASSWORD: nocobase
+    restart: always
+    volumes:
+      - ./storage/db/mysql:/var/lib/mysql
+    networks:
+      - nocobase
+```
+
+### Upgrade
+
+Previously, you would pull a new image for each update. Now, you need to build a new image for each update.
+
+```diff
+# Pull the latest image
+- docker-compose pull app
+# Rebuild the app container
++ docker-compose build app --pull
+# Start the app
+docker-compose up -d app
+# Check app logs
+docker-compose logs app
+```
+
+## Other Installation Methods
+If your NocoBase was installed with [create-nocobase-app](/welcome/getting-started/installation/create-nocobase-app) or [Git source code](/welcome/getting-started/installation/git-clone), please check the below MySQL official release page, choose the appropriate MySQL version, and follow the official installation guide.
+- History versions: https://downloads.mysql.com/archives/community/
+- Last versions: https://dev.mysql.com/downloads/mysql/

--- a/docs/en-US/handbook/backups/installation/postgres.md
+++ b/docs/en-US/handbook/backups/installation/postgres.md
@@ -1,0 +1,92 @@
+# Postgres Client Installation
+
+## Docker Installation
+
+### Enter the directory where the NocoBase Dockerfile is located and create a Dockerfile file
+
+```Dockerfile
+# Based on the next version
+FROM registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
+
+# Specify the desired PostgreSQL version, here we use version 16 as an example
+ARG PG_VERSION=16
+
+# Run installation script
+RUN apt update && apt install -y postgresql-common gnupg \
+  && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
+  && apt install -y postgresql-client-${PG_VERSION}
+```
+
+### Modify the docker-compose.yml file of NocoBase
+
+```diff
+version: "3"
+
+networks:
+  nocobase:
+    driver: bridge
+
+services:
+  app:
+-   image: registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
++   build:
++     dockerfile: Dockerfile
+    networks:
+      - nocobase
+    depends_on:
+      - postgres
+    environment:
+      # The application's secret key, used to generate user tokens, etc.
+      # If APP_KEY is changed, old tokens will also become invalid.
+      # It can be any random string, and make sure it is not exposed.
+      - APP_KEY=your-secret-key
+      # Database type, supports postgres, mysql, mariadb
+      - DB_DIALECT=postgres
+      # Database host, can be replaced with the IP of an existing database server
+      - DB_HOST=postgres
+      # Database name
+      - DB_DATABASE=nocobase
+      # Database user
+      - DB_USER=nocobase
+      # Database password
+      - DB_PASSWORD=nocobase
+      # Timezone
+      - TZ=Asia/Shanghai
+    volumes:
+      - ./storage:/app/nocobase/storage
+    ports:
+      - "13000:80"
+    # init: true
+
+  # If using an existing database server, postgres service can be omitted
+  postgres:
+    image: postgres:16
+    restart: always
+    command: postgres -c wal_level=logical
+    environment:
+      POSTGRES_USER: nocobase
+      POSTGRES_DB: nocobase
+      POSTGRES_PASSWORD: nocobase
+    volumes:
+      - ./storage/db/postgres:/var/lib/postgresql/data
+    networks:
+      - nocobase
+```
+
+### Upgrade
+
+Previously, you would pull a new image for each update. Now, you need to build a new image for each update.
+
+```diff
+# Pull the latest image
+- docker-compose pull app
+# Rebuild the app container
++ docker-compose build app --pull
+# Start the app
+docker-compose up -d app
+# Check app logs
+docker-compose logs app
+```
+
+## Other Installation Methods
+If your NocoBase was installed with [create-nocobase-app](/welcome/getting-started/installation/create-nocobase-app) or [Git source code](/welcome/getting-started/installation/git-clone), please check https://www.postgresql.org/download/, choose the appropriate PostgreSQL version, and follow the official installation guide.

--- a/docs/zh-CN/handbook/backups/index.md
+++ b/docs/zh-CN/handbook/backups/index.md
@@ -12,69 +12,11 @@ NocoBase 备份管理器插件，提供了 NocoBase 数据库及用户上传文�
 
 :::warning{title=注意}
 - 本插件是基于数据库原生客户端实现的，使用前需要在 NocoBase 服务器运行环境中安装对应数据库的客户端。
+  - [Postgres 数据库客户端安装](./installation/postgres.md)
+  - [MySQL 数据库客户端安装](./installation/mariadb.md)
+  - [MariaDB 数据库客户端安装](./installation/mariadb.md)
 - 还原操作时，目标数据库版本应当不低于创建该备份的数据库版本。
 :::
-
-### MySQL/MariaDB 客户端安装
-
-请选择<strong>还原备份时</strong>使用的数据库版本，以保证数据库版本兼容。
-
-#### Docker环境
-
-1. 访问 MySQL 官方发布页面，选择对应的 MySQL 版本，复制下载链接。
-- 历史版本： https://downloads.mysql.com/archives/community/
-- 最新版本： https://dev.mysql.com/downloads/mysql/
-
-NocoBase 镜像是基于 Debian 11 系统构建的，选择对应 Debian 11 系统的 MySQL 客户端版本，例如：从以上链接找到 8.1.0 版本下载地址为：https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_8.1.0-1debian11_amd64.deb
-
-2. 进入 NocoBase 容器
-```bash
-docker exec -it nocobase bash
-```
-
-3. 安装 MySQL 客户端
-```bash
-apt-get update && apt-get install -y wget
-wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_8.1.0-1debian11_amd64.deb
-dpkg -x mysql-community-client-core_8.1.0-1debian11_amd64.deb /tmp/mysql-client
-cp /tmp/mysql-client/usr/bin/mysqldump /usr/bin/
-cp /tmp/mysql-client/usr/bin/mysql /usr/bin/
-```
-
-#### 其它运行环境
-
-请访问 MySQL 官方发布页面，选择对应的 MySQL 版本，根据 MySQL 官方文档进行安装。
-- 历史版本： https://downloads.mysql.com/archives/community/
-- 最新版本： https://dev.mysql.com/downloads/mysql/
-
-### PostgreSQL 客户端安装
-
-请选择<strong>还原备份时</strong>使用的数据库版本，以保证数据库版本兼容。
-
-#### Docker 环境
-
-1. 进入 NocoBase 容器
-
-```bash
-# 独立docker启动的
-# docker exec -it nocobase bash
-
-# 官方docker compose 启动的
-docker compose exec -it app bash
-```
-
-2. 安装 PostgreSQL 客户端
-
-```bash
-apt install -y postgresql-common gnupg
-/usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-# postgresql-client-16 为16版本，根据实际情况选择对应版本
-apt install -y postgresql-client-16
-```
-
-#### 其它运行环境
-
-请访问https://www.postgresql.org/download/, 选择对应的 PostgreSQL 版本，并根据官方文档进行安装。
 
 ## 使用说明
 

--- a/docs/zh-CN/handbook/backups/index.md
+++ b/docs/zh-CN/handbook/backups/index.md
@@ -13,7 +13,7 @@ NocoBase 备份管理器插件，提供了 NocoBase 数据库及用户上传文�
 :::warning{title=注意}
 - 本插件是基于数据库原生客户端实现的，使用前需要在 NocoBase 服务器运行环境中安装对应数据库的客户端。
   - [Postgres 数据库客户端安装](./installation/postgres.md)
-  - [MySQL 数据库客户端安装](./installation/mariadb.md)
+  - [MySQL 数据库客户端安装](./installation/mysql.md)
   - [MariaDB 数据库客户端安装](./installation/mariadb.md)
 - 还原操作时，目标数据库版本应当不低于创建该备份的数据库版本。
 :::

--- a/docs/zh-CN/handbook/backups/installation/mariadb.md
+++ b/docs/zh-CN/handbook/backups/installation/mariadb.md
@@ -1,0 +1,107 @@
+# MariaDB 数据库客户端安装
+
+## Docker 安装
+
+### 进入 NocoBase Dockerfile 所在目录, 新建 Dockerfile 文件
+
+```Dockerfile
+# 基于 next 版本
+FROM registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
+
+# 国内用户用户要更新 sources.list
+RUN tee /etc/apt/sources.list > /dev/null <<EOF
+deb http://mirrors.aliyun.com/debian/ bullseye main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye main contrib non-free
+deb http://mirrors.aliyun.com/debian-security/ bullseye-security main contrib non-free
+deb-src http://mirrors.aliyun.com/debian-security/ bullseye-security main contrib non-free
+deb http://mirrors.aliyun.com/debian/ bullseye-updates main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye-updates main contrib non-free
+deb http://mirrors.aliyun.com/debian/ bullseye-backports main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye-backports main contrib non-free
+EOF
+
+# 执行安装脚本，选择最新的MySQL客户端版本
+RUN apt-get update && apt-get install -y wget && \
+  wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_8.1.0-1debian11_amd64.deb && \
+  dpkg -x mysql-community-client-core_8.1.0-1debian11_amd64.deb /tmp/mysql-client && \
+  cp /tmp/mysql-client/usr/bin/mysqldump /usr/bin/ &&\
+  cp /tmp/mysql-client/usr/bin/mysql /usr/bin/
+```
+
+### 修改 NocoBase 的 docker-compose.yml 文件
+
+```diff
+version: "3"
+
+networks:
+  nocobase:
+    driver: bridge
+
+services:
+  app:
+-   image: registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
++   build:
++     dockerfile: Dockerfile
+    networks:
+      - nocobase
+    depends_on:
+      - mariadb
+    environment:
+      # 应用的密钥，用于生成用户 token 等
+      # 如果 APP_KEY 修改了，旧的 token 也会随之失效
+      # 可以是任意随机字符串，并确保不对外泄露
+      - APP_KEY=your-secret-key
+      # 数据库类型，支持 postgres, mysql, mariadb, sqlite
+      - DB_DIALECT=mariadb
+      # 数据库主机，可以替换为已有的数据库服务器 IP
+      - DB_HOST=mariadb
+      # 数据库名
+      - DB_DATABASE=nocobase
+      # 数据库用户
+      - DB_USER=root
+      # 数据库密码
+      - DB_PASSWORD=nocobase
+      # 数据库表名、字段名是否转为 snake case 风格
+      - DB_UNDERSCORED=true
+      # 时区
+      - TZ=Asia/Shanghai
+    volumes:
+      - ./storage:/app/nocobase/storage
+    ports:
+      - "13000:80"
+    # init: true
+
+  # 如果使用已有数据库服务，可以不启动 mariadb
+  mariadb:
+    image: registry.cn-shanghai.aliyuncs.com/nocobase/mariadb:11
+    environment:
+      MYSQL_DATABASE: nocobase
+      MYSQL_USER: nocobase
+      MYSQL_PASSWORD: nocobase
+      MYSQL_ROOT_PASSWORD: nocobase
+    restart: always
+    volumes:
+      - ./storage/db/mariadb:/var/lib/mysql
+    networks:
+      - nocobase
+```
+
+### 升级
+
+以前每次更新都去 pull 新的镜像，改之后，每次都要 build 新的镜像
+
+```diff
+# 拉取最新镜像
+- docker-compose pull app
+# 更新 app 容器
++ docker-compose build app --pull
+# 启动
+docker-compose up -d app
+# 查看 app 进程的情况
+docker-compose logs app
+```
+
+## 其它方式安装
+
+如果您的 NocoBase 是使用[create-nocobase-app 安装](/welcome/getting-started/installation/create-nocobase-app) 或者 [Git 源码安装](/welcome/getting-started/installation/git-clone) 的，请访问 MySQL 官方发布页面进行安装。
+- 最新版本： https://dev.mysql.com/downloads/mysql/

--- a/docs/zh-CN/handbook/backups/installation/mysql.md
+++ b/docs/zh-CN/handbook/backups/installation/mysql.md
@@ -1,0 +1,103 @@
+# MySQL 数据库客户端安装
+
+## Docker 安装
+
+### 进入 NocoBase Dockerfile 所在目录, 新建 Dockerfile 文件
+
+```Dockerfile
+# 基于 next 版本
+FROM registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
+
+# 国内用户用户要更新 sources.list
+RUN tee /etc/apt/sources.list > /dev/null <<EOF
+deb http://mirrors.aliyun.com/debian/ bullseye main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye main contrib non-free
+deb http://mirrors.aliyun.com/debian-security/ bullseye-security main contrib non-free
+deb-src http://mirrors.aliyun.com/debian-security/ bullseye-security main contrib non-free
+deb http://mirrors.aliyun.com/debian/ bullseye-updates main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye-updates main contrib non-free
+deb http://mirrors.aliyun.com/debian/ bullseye-backports main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye-backports main contrib non-free
+EOF
+
+# 执行安装脚本，请根据实际情况替换成对应的 MySQL 版本链接
+RUN apt-get update && apt-get install -y wget && \
+ wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_8.1.0-1debian11_amd64.deb && \
+ dpkg -x mysql-community-client-core_8.1.0-1debian11_amd64.deb /tmp/mysql-client && \
+ cp /tmp/mysql-client/usr/bin/mysqldump /usr/bin/ &&\
+ cp /tmp/mysql-client/usr/bin/mysql /usr/bin/
+```
+
+### 修改 NocoBase 的 docker-compose.yml 文件
+
+```diff
+version: "3"
+networks:
+  nocobase:
+    driver: bridge
+services:
+  app:
+-   image: registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
++   build:
++     dockerfile: Dockerfile
+    networks:
+      - nocobase
+    depends_on:
+      - postgres
+    environment:
+      # 应用的密钥，用于生成用户 token 等
+      # 如果 APP_KEY 修改了，旧的 token 也会随之失效
+      # 可以是任意随机字符串，并确保不对外泄露
+      - APP_KEY=your-secret-key
+      # 数据库类型，支持 postgres, mysql, mariadb, sqlite
+      - DB_DIALECT=postgres
+      # 数据库主机，可以替换为已有的数据库服务器 IP
+      - DB_HOST=postgres
+      # 数据库名
+      - DB_DATABASE=nocobase
+      # 数据库用户
+      - DB_USER=nocobase
+      # 数据库密码
+      - DB_PASSWORD=nocobase
+      # 时区
+      - TZ=Asia/Shanghai
+    volumes:
+      - ./storage:/app/nocobase/storage
+    ports:
+      - "13000:80"
+    # init: true
+  # 如果使用已有数据库服务，可以不启动 postgres
+  postgres:
+    image: registry.cn-shanghai.aliyuncs.com/nocobase/postgres:16
+    restart: always
+    command: postgres -c wal_level=logical
+    environment:
+      POSTGRES_USER: nocobase
+      POSTGRES_DB: nocobase
+      POSTGRES_PASSWORD: nocobase
+    volumes:
+      - ./storage/db/postgres:/var/lib/postgresql/data
+    networks:
+      - nocobase
+```
+
+### 升级
+
+以前每次更新都去 pull 新的镜像，改之后，每次都要 build 新的镜像
+
+```diff
+# 拉取最新镜像
+- docker-compose pull app
+# 更新 app 容器
++ docker-compose build app --pull
+# 启动
+docker-compose up -d app
+# 查看 app 进程的情况
+docker-compose logs app
+```
+
+## 其它方式安装
+
+如果您的 NocoBase 是使用[create-nocobase-app 安装](/welcome/getting-started/installation/create-nocobase-app) 或者 [Git 源码安装](/welcome/getting-started/installation/git-clone) 的，请访问 MySQL 官方发布页面，选择对应的 MySQL 版本，根据 MySQL 官方文档进行安装。
+- 历史版本： https://downloads.mysql.com/archives/community/
+- 最新版本： https://dev.mysql.com/downloads/mysql/

--- a/docs/zh-CN/handbook/backups/installation/postgres.md
+++ b/docs/zh-CN/handbook/backups/installation/postgres.md
@@ -1,0 +1,102 @@
+# Postgres 数据库客户端安装
+
+## Docker 安装
+
+### 进入 NocoBase Dockerfile 所在目录, 新建 Dockerfile 文件
+
+```Dockerfile
+# 基于 next 版本
+FROM registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
+
+# 请根据实际情况选择对应版本, 这里选择 16 版本作为示例
+ARG PG_VERSION=16
+
+# 国内用户用户要更新 sources.list
+RUN tee /etc/apt/sources.list > /dev/null <<EOF
+deb http://mirrors.aliyun.com/debian/ bullseye main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye main contrib non-free
+deb http://mirrors.aliyun.com/debian-security/ bullseye-security main contrib non-free
+deb-src http://mirrors.aliyun.com/debian-security/ bullseye-security main contrib non-free
+deb http://mirrors.aliyun.com/debian/ bullseye-updates main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye-updates main contrib non-free
+deb http://mirrors.aliyun.com/debian/ bullseye-backports main contrib non-free
+deb-src http://mirrors.aliyun.com/debian/ bullseye-backports main contrib non-free
+EOF
+
+# 执行安装脚本
+RUN apt update && apt install -y postgresql-common gnupg \
+  && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
+  && apt install -y postgresql-client-${PG_VERSION}
+```
+
+### 修改 NocoBase 的 docker-compose.yml 文件
+
+```diff
+version: "3"
+networks:
+  nocobase:
+    driver: bridge
+services:
+  app:
+-   image: registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:next
++   build:
++     dockerfile: Dockerfile
+    networks:
+      - nocobase
+    depends_on:
+      - postgres
+    environment:
+      # 应用的密钥，用于生成用户 token 等，
+      # 如果 APP_KEY 修改了，旧的 token 也会随之失效
+      # 可以是任意随机字符串，并确保不对外泄露
+      - APP_KEY=your-secret-key
+      # 数据库类型，支持 postgres, mysql, mariadb, sqlite
+      - DB_DIALECT=postgres
+      # 数据库主机，可以替换为已有的数据库服务器 IP
+      - DB_HOST=postgres
+      # 数据库名
+      - DB_DATABASE=nocobase
+      # 数据库用户
+      - DB_USER=nocobase
+      # 数据库密码
+      - DB_PASSWORD=nocobase
+      # 时区
+      - TZ=Asia/Shanghai
+    volumes:
+      - ./storage:/app/nocobase/storage
+    ports:
+      - "13000:80"
+    # init: true
+  # 如果使用已有数据库服务，可以不启动 postgres
+  postgres:
+    image: registry.cn-shanghai.aliyuncs.com/nocobase/postgres:16
+    restart: always
+    command: postgres -c wal_level=logical
+    environment:
+      POSTGRES_USER: nocobase
+      POSTGRES_DB: nocobase
+      POSTGRES_PASSWORD: nocobase
+    volumes:
+      - ./storage/db/postgres:/var/lib/postgresql/data
+    networks:
+      - nocobase
+```
+
+### 升级
+
+以前每次更新都去 pull 新的镜像，改之后，每次都要 build 新的镜像
+
+```diff
+# 拉取最新镜像
+- docker-compose pull app
+# 更新 app 容器
++ docker-compose build app --pull
+# 启动
+docker-compose up -d app
+# 查看 app 进程的情况
+docker-compose logs app
+```
+
+## 其它方式安装
+
+如果您的 NocoBase 是使用[create-nocobase-app 安装](/welcome/getting-started/installation/create-nocobase-app) 或者 [Git 源码安装](/welcome/getting-started/installation/git-clone) 的，请访问https://www.postgresql.org/download/, 选择对应的 PostgreSQL 版本，并根据官方文档进行安装。


### PR DESCRIPTION
- Provide docker file for each sql client
- split sql client installation guidance into seperate doc