### PR TITLE
docker-compose en-US and fr-FR formatting fixes

### DIFF
--- a/docs/en-US/welcome/getting-started/installation/docker-compose.md
+++ b/docs/en-US/welcome/getting-started/installation/docker-compose.md
@@ -231,7 +231,7 @@ services:
     image: nocobase/nocobase:alpha
     image: nocobase/nocobase:1.3.51
 # ...
-` ` `
+```
 
 ## 3. Install and start NocoBase
 

--- a/docs/fr-FR/welcome/getting-started/installation/docker-compose.md
+++ b/docs/fr-FR/welcome/getting-started/installation/docker-compose.md
@@ -237,7 +237,7 @@ services:
     image: nocobase/nocobase:alpha
     image: nocobase/nocobase:1.3.51
 # ...
-` ` `
+```
 
 ## 3. Install and start NocoBase
 


### PR DESCRIPTION
Fixes en-US and fr-FR docker-compose.md page formatting to prevent step 3 being embedded in a code block and thus hard to find/read